### PR TITLE
Add Async MQTT library install

### DIFF
--- a/esp32_setup.py
+++ b/esp32_setup.py
@@ -47,6 +47,9 @@ if 'lib' in os.listdir('./'):
     if 'mqtt_async.py' not in os.listdir('lib/'):
     	# install the micropython mqtt library
         upip.install('micropython-mqtt')
+        # install the async micropython mqtt library
+        upip.install('micropython-mqtt-async')
+
 # if there is no 'lib directory', nothing has been downloaded
 else:
     # so download both libraries


### PR DESCRIPTION
Currently, the module `mqtt_async` is not installed by the setup script. This is likely because `mqtt_async` is provided in `micropython-mqtt-async` not `micropython-mqtt`. 

`micropython-mqtt`: https://github.com/peterhinch/micropython-mqtt 
`micropython-mqtt-async`: https://github.com/tve/mqboard/tree/master/mqtt_async

I've updated the setup script to include this dependency as well. 

I've also posted this as a question on the class discussion board. 